### PR TITLE
implement support for allowed sources IP range

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,47 @@ filtering in gitdub by setting the following configuration option:
     allowed_sources: [207.97.227.253, 50.57.128.197, 108.171.174.178]
 
 
+Installation as a service on Linux
+==================================
+Once you have gitdub working, you probably will want to make it into a service, so that it'll automatically start on reboot.
+
+You can either write your own script or you can use a pre-made script from this [repository](https://github.com/frdmn/service-daemons/). You just need to make a few minor tweaks to make it workable. Here is the [instructions page](https://blog.frd.mn/how-to-set-up-proper-startstop-services-ubuntu-debian-mac-windows/) with general details for this repository.
+
+If you are on a Ubuntu or a similar system that supports the `rc.d` system you can use [debian rc.d template](https://github.com/frdmn/service-daemons/blob/master/debian):
+
+    wget https://raw.github.com/frdmn/service-daemons/master/debian -O /etc/init.d/gitdub
+
+Edit `/etc/init.d/gitdub` and change the example settings to:
+
+    # The following assumes gitdub is setup under /var/gitdub/
+    NAME="gitdub"
+    PATH="/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/var/gitdub"
+    APPDIR="/var/gitdub"
+    APPBIN="/var/gitdub/gitdub"
+    APPARGS="config.yml"
+    USER="nobody"
+    GROUP="nobody"
+
+Depending on the user/group you are going to run it under you may have to change `USER` and `GROUP` settings as well.
+
+Make sure the script is executable:
+
+    chmod +x /etc/init.d/gitdub
+
+Enable the daemon with:
+
+    update-rc.d gitdub defaults
+
+Start the service with:
+
+    service gitdub start
+
+Stop the service with:
+
+    service gitdub stop
+
+If your system doesn't support the `rc.d` approach, check the [repository](https://github.com/frdmn/service-daemons/) for other methods.
+
 Licence
 =======
 

--- a/README.md
+++ b/README.md
@@ -94,47 +94,6 @@ filtering in gitdub by setting the following configuration option:
     allowed_sources: [207.97.227.253, 50.57.128.197, 108.171.174.178]
 
 
-Installation as a service on Linux
-==================================
-Once you have gitdub working, you probably will want to make it into a service, so that it'll automatically start on reboot.
-
-You can either write your own script or you can use a pre-made script from this [repository](https://github.com/frdmn/service-daemons/). You just need to make a few minor tweaks to make it workable. Here is the [instructions page](https://blog.frd.mn/how-to-set-up-proper-startstop-services-ubuntu-debian-mac-windows/) with general details for this repository.
-
-If you are on a Ubuntu or a similar system that supports the `rc.d` system you can use [debian rc.d template](https://github.com/frdmn/service-daemons/blob/master/debian):
-
-    wget https://raw.github.com/frdmn/service-daemons/master/debian -O /etc/init.d/gitdub
-
-Edit `/etc/init.d/gitdub` and change the example settings to:
-
-    # The following assumes gitdub is setup under /var/gitdub/
-    NAME="gitdub"
-    PATH="/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/var/gitdub"
-    APPDIR="/var/gitdub"
-    APPBIN="/var/gitdub/gitdub"
-    APPARGS="config.yml"
-    USER="nobody"
-    GROUP="nobody"
-
-Depending on the user/group you are going to run it under you may have to change `USER` and `GROUP` settings as well.
-
-Make sure the script is executable:
-
-    chmod +x /etc/init.d/gitdub
-
-Enable the daemon with:
-
-    update-rc.d gitdub defaults
-
-Start the service with:
-
-    service gitdub start
-
-Stop the service with:
-
-    service gitdub stop
-
-If your system doesn't support the `rc.d` approach, check the [repository](https://github.com/frdmn/service-daemons/) for other methods.
-
 Licence
 =======
 

--- a/README.md
+++ b/README.md
@@ -86,13 +86,15 @@ To prevent unauthorized access to the service, you can restrict the set of
 allowed source IP addresses to github addresses, e.g., via iptables:
 
     iptables -A INPUT -m state --state NEW -m tcp -p tcp \
-        -s 207.97.227.253,50.57.128.197,108.171.174.178 --dport 42042 -j ACCEPT
+        -s 192.30.252.0/22,185.199.108.0/22,140.82.112.0/20 --dport 42042 -j ACCEPT
 
 If that's not an option on your machine, you can also perform application-layer
 filtering in gitdub by setting the following configuration option:
 
-    allowed_sources: [207.97.227.253, 50.57.128.197, 108.171.174.178]
+    allowed_sources: [192.30.252.0/22, 185.199.108.0/22, 140.82.112.0/20]
 
+For an up-to-date listing of the github ip ranges, check the hooks section under 
+https://api.github.com/meta 
 
 Licence
 =======

--- a/config.yml.example
+++ b/config.yml.example
@@ -21,8 +21,9 @@ gitdub:
   # Only process POST requests from the these IP addresses (optioanl). If empty
   # or not set, gitdub processes requests from all addresses.
   #
-  # Github only.
-  #allowed_sources: [207.97.227.253, 50.57.128.197, 108.171.174.178]
+  # Github only: watch for up-to-date listing in the hooks section 
+  # here https://api.github.com/meta
+  #allowed_sources: [192.30.252.0/22, 185.199.108.0/22, 140.82.112.0/20]
   #
   allowed_sources: []
 

--- a/gitdub
+++ b/gitdub
@@ -5,6 +5,7 @@ require 'json'
 require 'logger'
 require 'sinatra/base'
 require 'yaml'
+require 'ipaddr'
 
 class GitNotifier
   STATE_FILE = '.git-notifier.dat'
@@ -135,7 +136,7 @@ class GitDubServer < Sinatra::Base
 
   post '/' do
     sources = settings.allowed_sources
-    if not sources.empty? and not sources.include?(request.ip)
+    if not sources.empty? and sources.none?{|block| IPAddr.new(block) === request.ip}
       $logger.info("discarding request from disallowed address #{request.ip}")
       return
     end


### PR DESCRIPTION
Here is an attempt at resolving https://github.com/mavam/gitdub/issues/6 and https://github.com/mavam/gitdub/issues/5

I don't speak ruby, but found a recipe [here](https://stackoverflow.com/a/13407292/9201239) and it seems to do the trick.

I tested the ip ranges to work on my setup. I haven't tested whether this still works with single IPs and not a range. github changes the IP most of the time, so I can't test it properly.